### PR TITLE
Fix published version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "viem-erc20",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "viem-erc20",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "19.8.1",

--- a/package.json
+++ b/package.json
@@ -72,13 +72,13 @@
   },
   "module": "./_esm/index.js",
   "sideEffects": false,
-  "typeVersions": {
+  "types": "./_types/index.d.ts",
+  "typesVersions": {
     "*": {
       "actions": [
         "./_types/actions/index.d.ts"
       ]
     }
   },
-  "types": "./_types/index.d.ts",
   "typings": "./_types/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viem-erc20",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Viem extensions for erc20 tokens",
   "keywords": [
     "erc20",


### PR DESCRIPTION
The published version failed with older Typescript configs because the field `typeVersions` is actually `typesVersions` (notice `type` => `types`)

Ideally, merge #2 first so I can publish from github the next version