### PR TITLE
Add cjs support

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,12 +10,5 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 1
-      - uses: hemilabs/actions/setup-node-env@main
-      - run: npm run --if-present prepublishOnly
-      # provenance is enabled by default in trusted publishing
-      - run: npm publish
+    uses: hemilabs/actions/.github/workflows/npm-publish.yml@v2
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .eslintcache
 .DS_Store
 .vscode
+_cjs
 _esm
 _types
 node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "viem-erc20",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "viem-erc20",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viem-erc20",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Viem extensions for erc20 tokens",
   "keywords": [
     "erc20",

--- a/package.json
+++ b/package.json
@@ -20,15 +20,18 @@
     "name": "Gonzalo D'Elia"
   },
   "files": [
-    "!test/*",
-    "*"
+    "_cjs",
+    "_esm",
+    "_types",
+    "src/**/*.ts"
   ],
   "repository": "hemilabs/viem-erc20",
   "scripts": {
-    "build": "npm run clean && npm run build:esm && npm run build:types",
+    "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:types",
+    "build:cjs": "tsc --noEmit false --module CommonJS --moduleResolution node --outDir ./_cjs --sourceMap && echo '{\"type\":\"commonjs\"}' > ./_cjs/package.json",
     "build:esm": "tsc --noEmit false --outDir ./_esm --sourceMap",
     "build:types": "tsc --noEmit false --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
-    "clean": "rm -rf ./_esm ./_types",
+    "clean": "rm -rf ./_cjs ./_esm ./_types",
     "deps:check": "knip",
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
@@ -64,10 +67,12 @@
   "exports": {
     ".": {
       "import": "./_esm/index.js",
+      "require": "./_cjs/index.js",
       "types": "./_types/index.d.ts"
     },
     "./actions": {
       "import": "./_esm/actions/index.js",
+      "require": "./_cjs/actions/index.js",
       "types": "./_types/actions/index.d.ts"
     }
   },


### PR DESCRIPTION
This PR adds CommonJs support for the package, so it can be used in repositories using commonJs (`require('foo')`)

I also updated the npm-publish workflow to work again using the hemilabs/action, now that it should work with trusted publishers (note: using v2)