### PR TITLE
Fix types condition order in exports

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -13,6 +13,6 @@ concurrency:
 
 jobs:
   run-checks-and-tests:
-    uses: hemilabs/actions/.github/workflows/js-checks.yml@06d5e0813de21d92283163864cce2e95ec5b67c6 # v1.0.0
+    uses: hemilabs/.github/.github/workflows/js-checks.yml@c0d930f1959633dd7dc1203d95ec6634dbaf9a34 # v1.2.0
     with:
       node-versions: '["20", "22", "24"]'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,5 +10,5 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: hemilabs/actions/.github/workflows/npm-publish.yml@c86350368ebf1124e81813d1497fb44606f3b6c1 # v2.0.0
+    uses: hemilabs/.github/.github/workflows/npm-publish.yml@c0d930f1959633dd7dc1203d95ec6634dbaf9a34 # v1.2.0
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -66,14 +66,14 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./_types/index.d.ts",
       "import": "./_esm/index.js",
-      "require": "./_cjs/index.js",
-      "types": "./_types/index.d.ts"
+      "require": "./_cjs/index.js"
     },
     "./actions": {
+      "types": "./_types/actions/index.d.ts",
       "import": "./_esm/actions/index.js",
-      "require": "./_cjs/actions/index.js",
-      "types": "./_types/actions/index.d.ts"
+      "require": "./_cjs/actions/index.js"
     }
   },
   "module": "./_esm/index.js",


### PR DESCRIPTION
## Summary
- Moves the `types` condition before `import` and `require` in the `exports` field of `package.json`

The `types` condition must come first so TypeScript resolves type definitions before the runtime entry points. With `types` last, it was never matched, producing these warnings on every `vitest run`:

```
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:71:6:
      71 │       "types": "./_types/index.d.ts"
         ╵       ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:69:6:
      69 │       "import": "./_esm/index.js",
         ╵       ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:70:6:
      70 │       "require": "./_cjs/index.js",
         ╵       ~~~~~~~~~
```


- Then on [796a5d8](https://github.com/hemilabs/viem-erc20/pull/11/commits/796a5d80a69541be657fbc0fc5193f6971f11ed0) I updated the hashes to use the fixed versions from [hemilabs/.github](https://github.com/hemilabs/.github)

## Test plan
- [x] `npm test` runs without warnings
- [x] No functional changes — only condition ordering in exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)