### PR TITLE
Bump dev dependencies to latest majors

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tsc": "tsc --noEmit"
   },
   "devDependencies": {
-    "@commitlint/cli": "^19.8.1",
+    "@commitlint/cli": "^21.0.2",
     "@hemilabs/anvil-fork-setup": "^2.0.0",
     "@tsconfig/node22": "^22.0.2",
     "better-sort-github-actions": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
-    "@hemilabs/anvil-fork-setup": "^1.0.1",
+    "@hemilabs/anvil-fork-setup": "^2.0.0",
     "@tsconfig/node22": "^22.0.2",
     "better-sort-github-actions": "^1.0.0",
     "better-sort-package-json": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-config-bloq": "^4.6.1",
     "husky": "^9.1.7",
     "knip": "^5.60.2",
-    "lint-staged": "^16.1.0",
+    "lint-staged": "^17.0.7",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",
     "viem": "^2.22.10",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^8.57.1",
     "eslint-config-bloq": "^4.6.1",
     "husky": "^9.1.7",
-    "knip": "^5.60.2",
+    "knip": "^6.15.0",
     "lint-staged": "^17.0.7",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       knip:
-        specifier: ^5.60.2
-        version: 5.88.1(@types/node@25.9.1)(typescript@5.9.3)
+        specifier: ^6.15.0
+        version: 6.15.0
       lint-staged:
         specifier: ^17.0.7
         version: 17.0.7
@@ -554,11 +554,225 @@ packages:
       }
     engines: { node: ">=12.4.0" }
 
+  "@oxc-parser/binding-android-arm-eabi@0.133.0":
+    resolution:
+      {
+        integrity: sha512-l/44caGse+VpnY9gx0yvvc5QnnG3yG1FO3KZgYvNL1GZrfK86zIwAOgGEVlxDyRymzrU/KHiblPFpevKOmJmUA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [android]
+
+  "@oxc-parser/binding-android-arm64@0.133.0":
+    resolution:
+      {
+        integrity: sha512-KUHmPMziLBp4u+zbrLdB7iWS7KshuZe+RAp7ELnY9SI9nNXBZ+dp8fiBqWOxhXqn+FQg3a4UcQhwmsJOKV8Jjg==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  "@oxc-parser/binding-darwin-arm64@0.133.0":
+    resolution:
+      {
+        integrity: sha512-q8dWmnU/8ea2tga9w2f1PinQ5rcMPDUGkF64T189b65YMjUomET4oy5oRldOr4AwOQkneOG/Zttnz1Dvrc62wg==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@oxc-parser/binding-darwin-x64@0.133.0":
+    resolution:
+      {
+        integrity: sha512-cOKeIELIB2bJnCKwqx4Rdj+1Lss/U6uCbLxRySZrhyOOQa1flKhwZFjEHRHxk8fU1NKmhK5OnTdPQ4CpjuFuVw==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@oxc-parser/binding-freebsd-x64@0.133.0":
+    resolution:
+      {
+        integrity: sha512-OpaSv4pW3KgFrMYQxTaS0aOE4T1DQF3qZE/4B6uqqv1KgPWWd4UQhJALi8PJPX1RRV5K7ThKXRfF7qGg2+3l1A==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.133.0":
+    resolution:
+      {
+        integrity: sha512-JGK1wlGrGwxBIlVSF7KWTX1/ru6BEtf28fRROztDRkLfiW+Kxa4onnriezMIiogfn9hVw2KzYcKiLjkLR2ns8A==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.133.0":
+    resolution:
+      {
+        integrity: sha512-yuZO533Ftonxn/iyoqQzURzLQHMspvsIyfiCSNi1t/ER4eIQaR0SsmUOUm5b/lmSig7IWIUa5/BrbEkAPwcilQ==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.133.0":
+    resolution:
+      {
+        integrity: sha512-hvpbqT5pN2rR+3+xtWeizwfR/aZ0vGceg6TqYMl+ToxMpk9/tmnX7kSvQnfEUkoua8mhogzvIKsAkn0wxgblBA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-arm64-musl@0.133.0":
+    resolution:
+      {
+        integrity: sha512-wJQGamIosQBoJHW9+S5XxrtKRo3eyJxsnS1XCPrqN0LHi8uw1pTqqTfn3t/NVuvbBg7Pumn4ez9Eidgcn0xbEg==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.133.0":
+    resolution:
+      {
+        integrity: sha512-Koaz32/O5+abIfrNGdyndgRvdOZ9jEf5/z3Ep9h3h2QWpdDiUQpVwgH0OcMXCs+l9aXxPLtkupqyVig9W6FDKw==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.133.0":
+    resolution:
+      {
+        integrity: sha512-R4vOjWzxhnNWHnVLeiB6jNuIifdy9vcMXZGPc7StXcxBovI+U2zg1QhZ9o8OjV80oGivs1lX5NfPLzk4IPqlRA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.133.0":
+    resolution:
+      {
+        integrity: sha512-iwgBNUTHiMdxARLYuM0SBlnYeb19iw1Ea5M+4ERZupCsBMLArti6FyZ6UfFjJxIiTDr2oW2DGQFxlQVQ/dW9rA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.133.0":
+    resolution:
+      {
+        integrity: sha512-ZwZNo8FZmB/gVfboQl+wXilBigGl+6nQQs+nITOeAP/HcAOjiHl6XZJL9F/KXNEspODQcbjAiyjUbeCJd9a0fA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-x64-gnu@0.133.0":
+    resolution:
+      {
+        integrity: sha512-govCvWx1dBlED3uu4qXctxpRcouu9I8Kn+DBktGCl760JtlGJzc9l/OmPJKlYWSbrRqKkMZehNeZ/4Wfma7uSA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-x64-musl@0.133.0":
+    resolution:
+      {
+        integrity: sha512-ssTlpXD5Mq9uCssDJPzlRWqBt4Y7Zzd9i+XZhWmK/9Y6KUIuAxVYTYiI8lxcGWi0+3/Cz4A8q9UrD4NK9Y2j7g==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-openharmony-arm64@0.133.0":
+    resolution:
+      {
+        integrity: sha512-51aByfXhPtLEdWG4a2Ihdw6cPWV1ei1AarALpFdDP8MLWDLE2NuUMgbo3DERR2Kt8fT/ok1GUvBiLxVGke9uUQ==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@oxc-parser/binding-wasm32-wasi@0.133.0":
+    resolution:
+      {
+        integrity: sha512-2e16tkKp+wDO2GTAmXfxbBcCmGEaFPIJEIRBBmVKNVXSc8/fJsSIaBGyFTPHM9ST5GNWgJcYIt94rDTks+PLwA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [wasm32]
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.133.0":
+    resolution:
+      {
+        integrity: sha512-KPTNDKbxH1cglrqTyVeXHb4Pk4oksz8EcE1/v8zqU7N4UXbiHfA/IwtXZ2U77fnRAWBbgVkl/lZbL7o3hRdejg==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.133.0":
+    resolution:
+      {
+        integrity: sha512-Una1bNYv9zCavQrfnDR9wuZVB3itLjCEH4Oz7i6CwAJN/Xq9b+zbbcxmvdkKvvJt4Ngc/MBmIYlbLo3zS4TQ0A==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ia32]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-x64-msvc@0.133.0":
+    resolution:
+      {
+        integrity: sha512-kjBhCiOGSYTwDJQuuZa7a94JbP8htWu7J0X1KwH74kV2K5eYf6eyJRYmkpCDvr0XEL8tMxYI4WU1VekblFCLgg==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
   "@oxc-project/types@0.132.0":
     resolution:
       {
         integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==,
         tarball: https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz,
+      }
+
+  "@oxc-project/types@0.133.0":
+    resolution:
+      {
+        integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==,
+        tarball: https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz,
       }
 
   "@oxc-resolver/binding-android-arm-eabi@11.20.0":
@@ -3580,17 +3794,14 @@ packages:
         tarball: https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz,
       }
 
-  knip@5.88.1:
+  knip@6.15.0:
     resolution:
       {
-        integrity: sha512-tpy5o7zu1MjawVkLPuahymVJekYY3kYjvzcoInhIchgePxTlo+api90tBv2KfhAIe5uXh+mez1tAfmbv8/TiZg==,
-        tarball: https://registry.npmjs.org/knip/-/knip-5.88.1.tgz,
+        integrity: sha512-uBaKFEGcu/HG4EY2gWFBMr+fBF43Jftoc2riJX51TKME1Z46C8UQIbNEusenYbEWihphxe2PY0Kns0yPvPYz4A==,
+        tarball: https://registry.npmjs.org/knip/-/knip-6.15.0.tgz,
       }
-    engines: { node: ">=18.18.0" }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
-    peerDependencies:
-      "@types/node": ">=18"
-      typescript: ">=5.0.4 <7"
 
   language-subtag-registry@0.3.23:
     resolution:
@@ -4082,6 +4293,14 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  oxc-parser@0.133.0:
+    resolution:
+      {
+        integrity: sha512-661RSx+ZcjBmjBYid+Fpp/2F5EbtildpeoZh5HdgnGs+jZ03nqQEQW8yGkt4BGyOC3OMPDQQRl8M5kqD2/g6jw==,
+        tarball: https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.133.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
 
   oxc-resolver@11.20.0:
     resolution:
@@ -4942,11 +5161,11 @@ packages:
         tarball: https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz,
       }
 
-  unbash@2.2.0:
+  unbash@3.0.0:
     resolution:
       {
-        integrity: sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w==,
-        tarball: https://registry.npmjs.org/unbash/-/unbash-2.2.0.tgz,
+        integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==,
+        tarball: https://registry.npmjs.org/unbash/-/unbash-3.0.0.tgz,
       }
     engines: { node: ">=14" }
 
@@ -5624,7 +5843,73 @@ snapshots:
 
   "@nolyfill/is-core-module@1.0.39": {}
 
+  "@oxc-parser/binding-android-arm-eabi@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-android-arm64@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-arm64@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-x64@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-freebsd-x64@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-musl@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-gnu@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-musl@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-openharmony-arm64@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-wasm32-wasi@0.133.0":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-x64-msvc@0.133.0":
+    optional: true
+
   "@oxc-project/types@0.132.0": {}
+
+  "@oxc-project/types@0.133.0": {}
 
   "@oxc-resolver/binding-android-arm-eabi@11.20.0":
     optional: true
@@ -7317,21 +7602,20 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knip@5.88.1(@types/node@25.9.1)(typescript@5.9.3):
+  knip@6.15.0:
     dependencies:
-      "@nodelib/fs.walk": 1.2.8
-      "@types/node": 25.9.1
-      fast-glob: 3.3.3
+      fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0
+      get-tsconfig: 4.14.0
       jiti: 2.7.0
       minimist: 1.2.8
+      oxc-parser: 0.133.0
       oxc-resolver: 11.20.0
-      picocolors: 1.1.1
       picomatch: 4.0.4
       smol-toml: 1.6.1
       strip-json-comments: 5.0.3
-      typescript: 5.9.3
-      unbash: 2.2.0
+      tinyglobby: 0.2.16
+      unbash: 3.0.0
       yaml: 2.9.0
       zod: 4.4.3
 
@@ -7589,6 +7873,31 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
+
+  oxc-parser@0.133.0:
+    dependencies:
+      "@oxc-project/types": 0.133.0
+    optionalDependencies:
+      "@oxc-parser/binding-android-arm-eabi": 0.133.0
+      "@oxc-parser/binding-android-arm64": 0.133.0
+      "@oxc-parser/binding-darwin-arm64": 0.133.0
+      "@oxc-parser/binding-darwin-x64": 0.133.0
+      "@oxc-parser/binding-freebsd-x64": 0.133.0
+      "@oxc-parser/binding-linux-arm-gnueabihf": 0.133.0
+      "@oxc-parser/binding-linux-arm-musleabihf": 0.133.0
+      "@oxc-parser/binding-linux-arm64-gnu": 0.133.0
+      "@oxc-parser/binding-linux-arm64-musl": 0.133.0
+      "@oxc-parser/binding-linux-ppc64-gnu": 0.133.0
+      "@oxc-parser/binding-linux-riscv64-gnu": 0.133.0
+      "@oxc-parser/binding-linux-riscv64-musl": 0.133.0
+      "@oxc-parser/binding-linux-s390x-gnu": 0.133.0
+      "@oxc-parser/binding-linux-x64-gnu": 0.133.0
+      "@oxc-parser/binding-linux-x64-musl": 0.133.0
+      "@oxc-parser/binding-openharmony-arm64": 0.133.0
+      "@oxc-parser/binding-wasm32-wasi": 0.133.0
+      "@oxc-parser/binding-win32-arm64-msvc": 0.133.0
+      "@oxc-parser/binding-win32-ia32-msvc": 0.133.0
+      "@oxc-parser/binding-win32-x64-msvc": 0.133.0
 
   oxc-resolver@11.20.0:
     optionalDependencies:
@@ -8073,7 +8382,7 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
-  unbash@2.2.0: {}
+  unbash@3.0.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
         specifier: ^19.8.1
         version: 19.8.1(@types/node@25.9.1)(typescript@5.9.3)
       "@hemilabs/anvil-fork-setup":
-        specifier: ^1.0.1
-        version: 1.0.1(vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)))
+        specifier: ^2.0.0
+        version: 2.0.0(vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)))
       "@tsconfig/node22":
         specifier: ^22.0.2
         version: 22.0.5
@@ -391,15 +391,18 @@ packages:
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
-  "@hemilabs/anvil-fork-setup@1.0.1":
+  "@hemilabs/anvil-fork-setup@2.0.0":
     resolution:
       {
-        integrity: sha512-nDKcZAfE5zwethmUxzm85119CtDz0lGsWfV9aVp46UbyquJrJXlwD1ccwmpl19+z/ZKm0rovd7JzIVjfLQgOhQ==,
-        tarball: https://registry.npmjs.org/@hemilabs/anvil-fork-setup/-/anvil-fork-setup-1.0.1.tgz,
+        integrity: sha512-zgYiJIsHEnuPw/soowX0nma7NhfX7SsxTFyxF0yl0shO8pI/YJXHeKtkVJX1S0f62P2HsXelQ/4Cz6bWfqS7+A==,
+        tarball: https://registry.npmjs.org/@hemilabs/anvil-fork-setup/-/anvil-fork-setup-2.0.0.tgz,
       }
     engines: { node: ">=20" }
     peerDependencies:
       vitest: ">=4"
+    peerDependenciesMeta:
+      vitest:
+        optional: true
 
   "@humanwhocodes/config-array@0.13.0":
     resolution:
@@ -5673,8 +5676,8 @@ snapshots:
 
   "@eslint/js@8.57.1": {}
 
-  "@hemilabs/anvil-fork-setup@1.0.1(vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)))":
-    dependencies:
+  "@hemilabs/anvil-fork-setup@2.0.0(vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)))":
+    optionalDependencies:
       vitest: 4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
 
   "@humanwhocodes/config-array@0.13.0":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^5.60.2
         version: 5.88.1(@types/node@25.9.1)(typescript@5.9.3)
       lint-staged:
-        specifier: ^16.1.0
-        version: 16.4.0
+        specifier: ^17.0.7
+        version: 17.0.7
       prettier:
         specifier: ^3.5.3
         version: 3.8.3
@@ -1877,21 +1877,6 @@ packages:
         integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
         tarball: https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz,
       }
-
-  colorette@2.0.20:
-    resolution:
-      {
-        integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
-        tarball: https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz,
-      }
-
-  commander@14.0.3:
-    resolution:
-      {
-        integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==,
-        tarball: https://registry.npmjs.org/commander/-/commander-14.0.3.tgz,
-      }
-    engines: { node: ">=20" }
 
   comment-parser@1.3.1:
     resolution:
@@ -3766,22 +3751,22 @@ packages:
         tarball: https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz,
       }
 
-  lint-staged@16.4.0:
+  lint-staged@17.0.7:
     resolution:
       {
-        integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==,
-        tarball: https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz,
+        integrity: sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==,
+        tarball: https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.7.tgz,
       }
-    engines: { node: ">=20.17" }
+    engines: { node: ">=22.22.1" }
     hasBin: true
 
-  listr2@9.0.5:
+  listr2@10.2.1:
     resolution:
       {
-        integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==,
-        tarball: https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz,
+        integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==,
+        tarball: https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz,
       }
-    engines: { node: ">=20.0.0" }
+    engines: { node: ">=22.13.0" }
 
   locate-path@6.0.0:
     resolution:
@@ -4827,6 +4812,14 @@ packages:
       }
     engines: { node: ">=18" }
 
+  tinyexec@1.2.4:
+    resolution:
+      {
+        integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==,
+        tarball: https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz,
+      }
+    engines: { node: ">=18" }
+
   tinyglobby@0.2.16:
     resolution:
       {
@@ -5173,6 +5166,14 @@ packages:
         tarball: https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz,
       }
     engines: { node: ">=0.10.0" }
+
+  wrap-ansi@10.0.0:
+    resolution:
+      {
+        integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==,
+        tarball: https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz,
+      }
+    engines: { node: ">=20" }
 
   wrap-ansi@7.0.0:
     resolution:
@@ -6265,10 +6266,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  colorette@2.0.20: {}
-
-  commander@14.0.3: {}
 
   comment-parser@1.3.1: {}
 
@@ -7404,23 +7401,22 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  lint-staged@16.4.0:
+  lint-staged@17.0.7:
     dependencies:
-      commander: 14.0.3
-      listr2: 9.0.5
+      listr2: 10.2.1
       picomatch: 4.0.4
       string-argv: 0.3.2
-      tinyexec: 1.2.3
+      tinyexec: 1.2.4
+    optionalDependencies:
       yaml: 2.9.0
 
-  listr2@9.0.5:
+  listr2@10.2.1:
     dependencies:
       cli-truncate: 5.2.0
-      colorette: 2.0.20
       eventemitter3: 5.0.4
       log-update: 6.1.0
       rfdc: 1.4.1
-      wrap-ansi: 9.0.2
+      wrap-ansi: 10.0.0
 
   locate-path@6.0.0:
     dependencies:
@@ -8003,6 +7999,8 @@ snapshots:
 
   tinyexec@1.2.3: {}
 
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8235,6 +8233,12 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.2.0
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
   .:
     devDependencies:
       "@commitlint/cli":
-        specifier: ^19.8.1
-        version: 19.8.1(@types/node@25.9.1)(typescript@5.9.3)
+        specifier: ^21.0.2
+        version: 21.0.2(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
       "@hemilabs/anvil-fork-setup":
         specifier: ^2.0.0
         version: 2.0.0(vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)))
@@ -24,7 +24,7 @@ importers:
         version: 1.1.1
       commitlint-config-bloq:
         specifier: ^1.1.0
-        version: 1.1.0(@commitlint/cli@19.8.1(@types/node@25.9.1)(typescript@5.9.3))
+        version: 1.1.0(@commitlint/cli@21.0.2(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -199,134 +199,150 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@commitlint/cli@19.8.1":
+  "@commitlint/cli@21.0.2":
     resolution:
       {
-        integrity: sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==,
-        tarball: https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz,
+        integrity: sha512-YMmfLbqBg+ZRvvmPhc+cilSQFrh/AgzVgCT1U/OifmUZEwPbvCtA8rN//YNaF9d5eoZphxVMGYtmwA2QgQORgg==,
+        tarball: https://registry.npmjs.org/@commitlint/cli/-/cli-21.0.2.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
     hasBin: true
 
-  "@commitlint/config-validator@19.8.1":
+  "@commitlint/config-validator@21.0.1":
     resolution:
       {
-        integrity: sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==,
-        tarball: https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz,
+        integrity: sha512-Zd2UFdndeMMaW2O96HK0tdfT4gOImUvidMpAd/pws2zZ4m1nrAZ/9b/v2JYuE8fs86GpXv9F7LNaIuCIWhY+pA==,
+        tarball: https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.0.1.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/ensure@19.8.1":
+  "@commitlint/ensure@21.0.1":
     resolution:
       {
-        integrity: sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==,
-        tarball: https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz,
+        integrity: sha512-jJ1037967wU7YN/xkv+iRlOBlmaOXPhPO5KQSqya6GyXzBlwuLzELBFao16DVg9dZyqmNrhewzwZ3SAibetHBQ==,
+        tarball: https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.0.1.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/execute-rule@19.8.1":
+  "@commitlint/execute-rule@21.0.1":
     resolution:
       {
-        integrity: sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==,
-        tarball: https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz,
+        integrity: sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==,
+        tarball: https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/format@19.8.1":
+  "@commitlint/format@21.0.1":
     resolution:
       {
-        integrity: sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==,
-        tarball: https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz,
+        integrity: sha512-ksmG2+cHGtuDPQQbhBbC4unwm444+6TiPw0d1bKf67hntgZqZ8E0g1MuYKUuyT5IH4IMmXZhKq22/Z3jBvtQIw==,
+        tarball: https://registry.npmjs.org/@commitlint/format/-/format-21.0.1.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/is-ignored@19.8.1":
+  "@commitlint/is-ignored@21.0.2":
     resolution:
       {
-        integrity: sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==,
-        tarball: https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz,
+        integrity: sha512-H5z4t8PC9tUsmZ/o+EptM3Nq8sTFtskAShdcqxCoyzklW5eaVT5xbrDAET2uypzir9Vsj4ZZmBtyKjYe2XqgeQ==,
+        tarball: https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.0.2.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/lint@19.8.1":
+  "@commitlint/lint@21.0.2":
     resolution:
       {
-        integrity: sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==,
-        tarball: https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz,
+        integrity: sha512-PnUmLYGeGLfW8oVatR9KpNxSHYAnJOEWlMZzfdeFOUq6WUrFx1fGQaWCWJqMoIll/xPM+GdfJV+tKHZVHhl0Fg==,
+        tarball: https://registry.npmjs.org/@commitlint/lint/-/lint-21.0.2.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/load@19.8.1":
+  "@commitlint/load@21.0.2":
     resolution:
       {
-        integrity: sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==,
-        tarball: https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz,
+        integrity: sha512-lwUE70hN0/qE/ZRROhbaX65ly/FF12DrqfReLCESo37M0OQCFAf2jRS+2tSCSORq+bm4Kdju7qNDj46uc1QzTA==,
+        tarball: https://registry.npmjs.org/@commitlint/load/-/load-21.0.2.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/message@19.8.1":
+  "@commitlint/message@21.0.2":
     resolution:
       {
-        integrity: sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==,
-        tarball: https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz,
+        integrity: sha512-5n4aqHGD/FNnom/D5L8i7cYtV+xjuXcBL832C3w9VglEsZzIsoHpJsvxzJ7cgiOsOdc/2jU4t5+7qMHh7GBX3g==,
+        tarball: https://registry.npmjs.org/@commitlint/message/-/message-21.0.2.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/parse@19.8.1":
+  "@commitlint/parse@21.0.2":
     resolution:
       {
-        integrity: sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==,
-        tarball: https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz,
+        integrity: sha512-QVZJhGHTm+oiuWyEKOCTQ0ZM3mfJ0eGWFeHuj7WzSKEth+UukcCHac9GD8pgdFlg/qGkFWOtyaNd1T8REgagaw==,
+        tarball: https://registry.npmjs.org/@commitlint/parse/-/parse-21.0.2.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/read@19.8.1":
+  "@commitlint/read@21.0.2":
     resolution:
       {
-        integrity: sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==,
-        tarball: https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz,
+        integrity: sha512-BtsrnLVycSSKf4Q0gMch4giCj5NNlmcbhc8ra5vONgGtP2IjRDo33bEFtr5Pm+2N+5fXGWb2MksWPrspPfdhdw==,
+        tarball: https://registry.npmjs.org/@commitlint/read/-/read-21.0.2.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/resolve-extends@19.8.1":
+  "@commitlint/resolve-extends@21.0.1":
     resolution:
       {
-        integrity: sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==,
-        tarball: https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz,
+        integrity: sha512-0DhjYWL6uYrY16Efa032fYk3woGJDU4AGWiG1XXltT9AMUNYKyb5cIZU2ivbaMZ3+kKFqUjikD2cjh66Sbh/Sg==,
+        tarball: https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.0.1.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/rules@19.8.1":
+  "@commitlint/rules@21.0.2":
     resolution:
       {
-        integrity: sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==,
-        tarball: https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz,
+        integrity: sha512-k6tQ69Td7t2qUSIbik8D3TL1q3ZJpkEbV+yLogDzCRAdOxJm4ndhtBNREsLA1/puRfWvzS9eioF2w43WT+hHgQ==,
+        tarball: https://registry.npmjs.org/@commitlint/rules/-/rules-21.0.2.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/to-lines@19.8.1":
+  "@commitlint/to-lines@21.0.1":
     resolution:
       {
-        integrity: sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==,
-        tarball: https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz,
+        integrity: sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==,
+        tarball: https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/top-level@19.8.1":
+  "@commitlint/top-level@21.0.2":
     resolution:
       {
-        integrity: sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==,
-        tarball: https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz,
+        integrity: sha512-s9KKM+e+mXgFeIh4n7KmOGAVT3mkJ3Fp1bBYHIK5pjeUwlEMzp/tZfb5u0Poa680AsQTXMEMRxZi1vQ9m2X5ug==,
+        tarball: https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.2.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
 
-  "@commitlint/types@19.8.1":
+  "@commitlint/types@21.0.1":
     resolution:
       {
-        integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==,
-        tarball: https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz,
+        integrity: sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==,
+        tarball: https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz,
       }
-    engines: { node: ">=v18" }
+    engines: { node: ">=22.12.0" }
+
+  "@conventional-changelog/git-client@2.7.0":
+    resolution:
+      {
+        integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==,
+        tarball: https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      conventional-commits-filter: ^5.0.0
+      conventional-commits-parser: ^6.4.0
+    peerDependenciesMeta:
+      conventional-commits-filter:
+        optional: true
+      conventional-commits-parser:
+        optional: true
 
   "@emnapi/core@1.10.0":
     resolution:
@@ -929,6 +945,22 @@ packages:
         tarball: https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz,
       }
 
+  "@simple-libs/child-process-utils@1.0.2":
+    resolution:
+      {
+        integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==,
+        tarball: https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz,
+      }
+    engines: { node: ">=18" }
+
+  "@simple-libs/stream-utils@1.2.0":
+    resolution:
+      {
+        integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==,
+        tarball: https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz,
+      }
+    engines: { node: ">=18" }
+
   "@standard-schema/spec@1.1.0":
     resolution:
       {
@@ -955,13 +987,6 @@ packages:
       {
         integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
         tarball: https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz,
-      }
-
-  "@types/conventional-commits-parser@5.0.2":
-    resolution:
-      {
-        integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==,
-        tarball: https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.2.tgz,
       }
 
   "@types/deep-eql@4.0.2":
@@ -1434,14 +1459,6 @@ packages:
         tarball: https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz,
       }
 
-  JSONStream@1.3.5:
-    resolution:
-      {
-        integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==,
-        tarball: https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz,
-      }
-    hasBin: true
-
   abitype@1.2.3:
     resolution:
       {
@@ -1814,14 +1831,6 @@ packages:
       }
     engines: { node: ">=10" }
 
-  chalk@5.6.2:
-    resolution:
-      {
-        integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==,
-        tarball: https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz,
-      }
-    engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
-
   cli-cursor@5.0.0:
     resolution:
       {
@@ -1845,6 +1854,14 @@ packages:
         tarball: https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz,
       }
     engines: { node: ">=12" }
+
+  cliui@9.0.1:
+    resolution:
+      {
+        integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==,
+        tarball: https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz,
+      }
+    engines: { node: ">=20" }
 
   color-convert@2.0.1:
     resolution:
@@ -1908,21 +1925,21 @@ packages:
         tarball: https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz,
       }
 
-  conventional-changelog-angular@7.0.0:
+  conventional-changelog-angular@8.3.1:
     resolution:
       {
-        integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==,
-        tarball: https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz,
+        integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==,
+        tarball: https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz,
       }
-    engines: { node: ">=16" }
+    engines: { node: ">=18" }
 
-  conventional-commits-parser@5.0.0:
+  conventional-commits-parser@6.4.0:
     resolution:
       {
-        integrity: sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==,
-        tarball: https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz,
+        integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==,
+        tarball: https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz,
       }
-    engines: { node: ">=16" }
+    engines: { node: ">=18" }
     hasBin: true
 
   convert-source-map@2.0.0:
@@ -1971,14 +1988,6 @@ packages:
         integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==,
         tarball: https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz,
       }
-
-  dargs@8.1.0:
-    resolution:
-      {
-        integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==,
-        tarball: https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz,
-      }
-    engines: { node: ">=12" }
 
   data-view-buffer@1.0.2:
     resolution:
@@ -2269,6 +2278,13 @@ packages:
         tarball: https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz,
       }
     engines: { node: ">= 0.4" }
+
+  es-toolkit@1.47.0:
+    resolution:
+      {
+        integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==,
+        tarball: https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz,
+      }
 
   escalade@3.2.0:
     resolution:
@@ -2801,14 +2817,6 @@ packages:
       }
     engines: { node: ">=10" }
 
-  find-up@7.0.0:
-    resolution:
-      {
-        integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==,
-        tarball: https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz,
-      }
-    engines: { node: ">=18" }
-
   flat-cache@3.2.0:
     resolution:
       {
@@ -2949,14 +2957,13 @@ packages:
         tarball: https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-4.2.1.tgz,
       }
 
-  git-raw-commits@4.0.0:
+  git-raw-commits@5.0.1:
     resolution:
       {
-        integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==,
-        tarball: https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz,
+        integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==,
+        tarball: https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz,
       }
-    engines: { node: ">=16" }
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    engines: { node: ">=18" }
     hasBin: true
 
   glob-parent@5.1.2:
@@ -2991,13 +2998,13 @@ packages:
       }
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  global-directory@4.0.1:
+  global-directory@5.0.0:
     resolution:
       {
-        integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==,
-        tarball: https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz,
+        integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==,
+        tarball: https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20" }
 
   globals@13.24.0:
     resolution:
@@ -3126,13 +3133,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  import-meta-resolve@4.2.0:
-    resolution:
-      {
-        integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==,
-        tarball: https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz,
-      }
-
   imurmurhash@0.1.4:
     resolution:
       {
@@ -3156,13 +3156,13 @@ packages:
         tarball: https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz,
       }
 
-  ini@4.1.1:
+  ini@6.0.0:
     resolution:
       {
-        integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==,
-        tarball: https://registry.npmjs.org/ini/-/ini-4.1.1.tgz,
+        integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==,
+        tarball: https://registry.npmjs.org/ini/-/ini-6.0.0.tgz,
       }
-    engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
   internal-slot@1.1.0:
     resolution:
@@ -3394,14 +3394,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  is-text-path@2.0.0:
-    resolution:
-      {
-        integrity: sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==,
-        tarball: https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz,
-      }
-    engines: { node: ">=8" }
-
   is-typed-array@1.1.15:
     resolution:
       {
@@ -3587,14 +3579,6 @@ packages:
         integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==,
         tarball: https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz,
       }
-
-  jsonparse@1.3.1:
-    resolution:
-      {
-        integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==,
-        tarball: https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz,
-      }
-    engines: { "0": node >= 0.2.0 }
 
   jsx-ast-utils@3.3.5:
     resolution:
@@ -3807,75 +3791,11 @@ packages:
       }
     engines: { node: ">=10" }
 
-  locate-path@7.2.0:
-    resolution:
-      {
-        integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==,
-        tarball: https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-
-  lodash.camelcase@4.3.0:
-    resolution:
-      {
-        integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==,
-        tarball: https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz,
-      }
-
-  lodash.isplainobject@4.0.6:
-    resolution:
-      {
-        integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==,
-        tarball: https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz,
-      }
-
-  lodash.kebabcase@4.1.1:
-    resolution:
-      {
-        integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==,
-        tarball: https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz,
-      }
-
   lodash.merge@4.6.2:
     resolution:
       {
         integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
         tarball: https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz,
-      }
-
-  lodash.mergewith@4.6.2:
-    resolution:
-      {
-        integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==,
-        tarball: https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz,
-      }
-
-  lodash.snakecase@4.1.1:
-    resolution:
-      {
-        integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==,
-        tarball: https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz,
-      }
-
-  lodash.startcase@4.4.0:
-    resolution:
-      {
-        integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==,
-        tarball: https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz,
-      }
-
-  lodash.uniq@4.5.0:
-    resolution:
-      {
-        integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==,
-        tarball: https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz,
-      }
-
-  lodash.upperfirst@4.3.1:
-    resolution:
-      {
-        integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==,
-        tarball: https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz,
       }
 
   log-update@6.1.0:
@@ -3947,13 +3867,13 @@ packages:
         tarball: https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz,
       }
 
-  meow@12.1.1:
+  meow@13.2.0:
     resolution:
       {
-        integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==,
-        tarball: https://registry.npmjs.org/meow/-/meow-12.1.1.tgz,
+        integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==,
+        tarball: https://registry.npmjs.org/meow/-/meow-13.2.0.tgz,
       }
-    engines: { node: ">=16.10" }
+    engines: { node: ">=18" }
 
   merge2@1.4.1:
     resolution:
@@ -4193,14 +4113,6 @@ packages:
       }
     engines: { node: ">=10" }
 
-  p-limit@4.0.0:
-    resolution:
-      {
-        integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==,
-        tarball: https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-
   p-locate@5.0.0:
     resolution:
       {
@@ -4208,14 +4120,6 @@ packages:
         tarball: https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz,
       }
     engines: { node: ">=10" }
-
-  p-locate@6.0.0:
-    resolution:
-      {
-        integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==,
-        tarball: https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   package-json-validator@0.10.2:
     resolution:
@@ -4249,14 +4153,6 @@ packages:
         tarball: https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz,
       }
     engines: { node: ">=8" }
-
-  path-exists@5.0.0:
-    resolution:
-      {
-        integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==,
-        tarball: https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   path-is-absolute@1.0.1:
     resolution:
@@ -4737,14 +4633,6 @@ packages:
         tarball: https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz,
       }
 
-  split2@4.2.0:
-    resolution:
-      {
-        integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
-        tarball: https://registry.npmjs.org/split2/-/split2-4.2.0.tgz,
-      }
-    engines: { node: ">= 10.x" }
-
   stable-hash@0.0.5:
     resolution:
       {
@@ -4917,26 +4805,11 @@ packages:
       }
     engines: { node: ^14.18.0 || >=16.0.0 }
 
-  text-extensions@2.4.0:
-    resolution:
-      {
-        integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==,
-        tarball: https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz,
-      }
-    engines: { node: ">=8" }
-
   text-table@0.2.0:
     resolution:
       {
         integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==,
         tarball: https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz,
-      }
-
-  through@2.3.8:
-    resolution:
-      {
-        integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==,
-        tarball: https://registry.npmjs.org/through/-/through-2.3.8.tgz,
       }
 
   tinybench@2.9.0:
@@ -5098,14 +4971,6 @@ packages:
         integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==,
         tarball: https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz,
       }
-
-  unicorn-magic@0.1.0:
-    resolution:
-      {
-        integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==,
-        tarball: https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz,
-      }
-    engines: { node: ">=18" }
 
   unrs-resolver@1.12.2:
     resolution:
@@ -5380,6 +5245,14 @@ packages:
       }
     engines: { node: ">=12" }
 
+  yargs-parser@22.0.0:
+    resolution:
+      {
+        integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==,
+        tarball: https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
+
   yargs@17.7.2:
     resolution:
       {
@@ -5388,6 +5261,14 @@ packages:
       }
     engines: { node: ">=12" }
 
+  yargs@18.0.0:
+    resolution:
+      {
+        integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==,
+        tarball: https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
+
   yocto-queue@0.1.0:
     resolution:
       {
@@ -5395,14 +5276,6 @@ packages:
         tarball: https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz,
       }
     engines: { node: ">=10" }
-
-  yocto-queue@1.2.2:
-    resolution:
-      {
-        integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==,
-        tarball: https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz,
-      }
-    engines: { node: ">=12.20" }
 
   zod-validation-error@4.0.2:
     resolution:
@@ -5526,110 +5399,116 @@ snapshots:
       "@babel/helper-string-parser": 7.29.7
       "@babel/helper-validator-identifier": 7.29.7
 
-  "@commitlint/cli@19.8.1(@types/node@25.9.1)(typescript@5.9.3)":
+  "@commitlint/cli@21.0.2(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)":
     dependencies:
-      "@commitlint/format": 19.8.1
-      "@commitlint/lint": 19.8.1
-      "@commitlint/load": 19.8.1(@types/node@25.9.1)(typescript@5.9.3)
-      "@commitlint/read": 19.8.1
-      "@commitlint/types": 19.8.1
+      "@commitlint/format": 21.0.1
+      "@commitlint/lint": 21.0.2
+      "@commitlint/load": 21.0.2(@types/node@25.9.1)(typescript@5.9.3)
+      "@commitlint/read": 21.0.2(conventional-commits-parser@6.4.0)
+      "@commitlint/types": 21.0.1
       tinyexec: 1.2.3
-      yargs: 17.7.2
+      yargs: 18.0.0
     transitivePeerDependencies:
       - "@types/node"
+      - conventional-commits-filter
+      - conventional-commits-parser
       - typescript
 
-  "@commitlint/config-validator@19.8.1":
+  "@commitlint/config-validator@21.0.1":
     dependencies:
-      "@commitlint/types": 19.8.1
+      "@commitlint/types": 21.0.1
       ajv: 8.20.0
 
-  "@commitlint/ensure@19.8.1":
+  "@commitlint/ensure@21.0.1":
     dependencies:
-      "@commitlint/types": 19.8.1
-      lodash.camelcase: 4.3.0
-      lodash.kebabcase: 4.1.1
-      lodash.snakecase: 4.1.1
-      lodash.startcase: 4.4.0
-      lodash.upperfirst: 4.3.1
+      "@commitlint/types": 21.0.1
+      es-toolkit: 1.47.0
 
-  "@commitlint/execute-rule@19.8.1": {}
+  "@commitlint/execute-rule@21.0.1": {}
 
-  "@commitlint/format@19.8.1":
+  "@commitlint/format@21.0.1":
     dependencies:
-      "@commitlint/types": 19.8.1
-      chalk: 5.6.2
+      "@commitlint/types": 21.0.1
+      picocolors: 1.1.1
 
-  "@commitlint/is-ignored@19.8.1":
+  "@commitlint/is-ignored@21.0.2":
     dependencies:
-      "@commitlint/types": 19.8.1
+      "@commitlint/types": 21.0.1
       semver: 7.8.1
 
-  "@commitlint/lint@19.8.1":
+  "@commitlint/lint@21.0.2":
     dependencies:
-      "@commitlint/is-ignored": 19.8.1
-      "@commitlint/parse": 19.8.1
-      "@commitlint/rules": 19.8.1
-      "@commitlint/types": 19.8.1
+      "@commitlint/is-ignored": 21.0.2
+      "@commitlint/parse": 21.0.2
+      "@commitlint/rules": 21.0.2
+      "@commitlint/types": 21.0.1
 
-  "@commitlint/load@19.8.1(@types/node@25.9.1)(typescript@5.9.3)":
+  "@commitlint/load@21.0.2(@types/node@25.9.1)(typescript@5.9.3)":
     dependencies:
-      "@commitlint/config-validator": 19.8.1
-      "@commitlint/execute-rule": 19.8.1
-      "@commitlint/resolve-extends": 19.8.1
-      "@commitlint/types": 19.8.1
-      chalk: 5.6.2
+      "@commitlint/config-validator": 21.0.1
+      "@commitlint/execute-rule": 21.0.1
+      "@commitlint/resolve-extends": 21.0.1
+      "@commitlint/types": 21.0.1
       cosmiconfig: 9.0.1(typescript@5.9.3)
       cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
-      lodash.isplainobject: 4.0.6
-      lodash.merge: 4.6.2
-      lodash.uniq: 4.5.0
+      es-toolkit: 1.47.0
+      is-plain-obj: 4.1.0
+      picocolors: 1.1.1
     transitivePeerDependencies:
       - "@types/node"
       - typescript
 
-  "@commitlint/message@19.8.1": {}
+  "@commitlint/message@21.0.2": {}
 
-  "@commitlint/parse@19.8.1":
+  "@commitlint/parse@21.0.2":
     dependencies:
-      "@commitlint/types": 19.8.1
-      conventional-changelog-angular: 7.0.0
-      conventional-commits-parser: 5.0.0
+      "@commitlint/types": 21.0.1
+      conventional-changelog-angular: 8.3.1
+      conventional-commits-parser: 6.4.0
 
-  "@commitlint/read@19.8.1":
+  "@commitlint/read@21.0.2(conventional-commits-parser@6.4.0)":
     dependencies:
-      "@commitlint/top-level": 19.8.1
-      "@commitlint/types": 19.8.1
-      git-raw-commits: 4.0.0
-      minimist: 1.2.8
+      "@commitlint/top-level": 21.0.2
+      "@commitlint/types": 21.0.1
+      git-raw-commits: 5.0.1(conventional-commits-parser@6.4.0)
       tinyexec: 1.2.3
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
 
-  "@commitlint/resolve-extends@19.8.1":
+  "@commitlint/resolve-extends@21.0.1":
     dependencies:
-      "@commitlint/config-validator": 19.8.1
-      "@commitlint/types": 19.8.1
-      global-directory: 4.0.1
-      import-meta-resolve: 4.2.0
-      lodash.mergewith: 4.6.2
+      "@commitlint/config-validator": 21.0.1
+      "@commitlint/types": 21.0.1
+      es-toolkit: 1.47.0
+      global-directory: 5.0.0
       resolve-from: 5.0.0
 
-  "@commitlint/rules@19.8.1":
+  "@commitlint/rules@21.0.2":
     dependencies:
-      "@commitlint/ensure": 19.8.1
-      "@commitlint/message": 19.8.1
-      "@commitlint/to-lines": 19.8.1
-      "@commitlint/types": 19.8.1
+      "@commitlint/ensure": 21.0.1
+      "@commitlint/message": 21.0.2
+      "@commitlint/to-lines": 21.0.1
+      "@commitlint/types": 21.0.1
 
-  "@commitlint/to-lines@19.8.1": {}
+  "@commitlint/to-lines@21.0.1": {}
 
-  "@commitlint/top-level@19.8.1":
+  "@commitlint/top-level@21.0.2":
     dependencies:
-      find-up: 7.0.0
+      escalade: 3.2.0
 
-  "@commitlint/types@19.8.1":
+  "@commitlint/types@21.0.1":
     dependencies:
-      "@types/conventional-commits-parser": 5.0.2
-      chalk: 5.6.2
+      conventional-commits-parser: 6.4.0
+      picocolors: 1.1.1
+
+  "@conventional-changelog/git-client@2.7.0(conventional-commits-parser@6.4.0)":
+    dependencies:
+      "@simple-libs/child-process-utils": 1.0.2
+      "@simple-libs/stream-utils": 1.2.0
+      semver: 7.8.1
+    optionalDependencies:
+      conventional-commits-parser: 6.4.0
 
   "@emnapi/core@1.10.0":
     dependencies:
@@ -5877,6 +5756,12 @@ snapshots:
       "@noble/hashes": 1.8.0
       "@scure/base": 1.2.6
 
+  "@simple-libs/child-process-utils@1.0.2":
+    dependencies:
+      "@simple-libs/stream-utils": 1.2.0
+
+  "@simple-libs/stream-utils@1.2.0": {}
+
   "@standard-schema/spec@1.1.0": {}
 
   "@tsconfig/node22@22.0.5": {}
@@ -5890,10 +5775,6 @@ snapshots:
     dependencies:
       "@types/deep-eql": 4.0.2
       assertion-error: 2.0.1
-
-  "@types/conventional-commits-parser@5.0.2":
-    dependencies:
-      "@types/node": 25.9.1
 
   "@types/deep-eql@4.0.2": {}
 
@@ -6161,11 +6042,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  JSONStream@1.3.5:
-    dependencies:
-      jsonparse: 1.3.1
-      through: 2.3.8
-
   abitype@1.2.3(typescript@5.9.3)(zod@4.4.3):
     optionalDependencies:
       typescript: 5.9.3
@@ -6363,8 +6239,6 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.6.2: {}
-
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -6380,6 +6254,12 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -6392,9 +6272,9 @@ snapshots:
 
   comment-parser@1.3.1: {}
 
-  commitlint-config-bloq@1.1.0(@commitlint/cli@19.8.1(@types/node@25.9.1)(typescript@5.9.3)):
+  commitlint-config-bloq@1.1.0(@commitlint/cli@21.0.2(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)):
     dependencies:
-      "@commitlint/cli": 19.8.1(@types/node@25.9.1)(typescript@5.9.3)
+      "@commitlint/cli": 21.0.2(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
 
   compare-func@2.0.0:
     dependencies:
@@ -6403,16 +6283,14 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  conventional-changelog-angular@7.0.0:
+  conventional-changelog-angular@8.3.1:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-commits-parser@5.0.0:
+  conventional-commits-parser@6.4.0:
     dependencies:
-      JSONStream: 1.3.5
-      is-text-path: 2.0.0
-      meow: 12.1.1
-      split2: 4.2.0
+      "@simple-libs/stream-utils": 1.2.0
+      meow: 13.2.0
 
   convert-source-map@2.0.0: {}
 
@@ -6439,8 +6317,6 @@ snapshots:
       which: 2.0.2
 
   damerau-levenshtein@1.0.8: {}
-
-  dargs@8.1.0: {}
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -6636,6 +6512,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.47.0: {}
 
   escalade@3.2.0: {}
 
@@ -7059,12 +6937,6 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  find-up@7.0.0:
-    dependencies:
-      locate-path: 7.2.0
-      path-exists: 5.0.0
-      unicorn-magic: 0.1.0
-
   flat-cache@3.2.0:
     dependencies:
       flatted: 3.4.2
@@ -7137,11 +7009,13 @@ snapshots:
 
   git-hooks-list@4.2.1: {}
 
-  git-raw-commits@4.0.0:
+  git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
     dependencies:
-      dargs: 8.1.0
-      meow: 12.1.1
-      split2: 4.2.0
+      "@conventional-changelog/git-client": 2.7.0(conventional-commits-parser@6.4.0)
+      meow: 13.2.0
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
 
   glob-parent@5.1.2:
     dependencies:
@@ -7169,9 +7043,9 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  global-directory@4.0.1:
+  global-directory@5.0.0:
     dependencies:
-      ini: 4.1.1
+      ini: 6.0.0
 
   globals@13.24.0:
     dependencies:
@@ -7228,8 +7102,6 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-meta-resolve@4.2.0: {}
-
   imurmurhash@0.1.4: {}
 
   inflight@1.0.6:
@@ -7239,7 +7111,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@4.1.1: {}
+  ini@6.0.0: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -7358,10 +7230,6 @@ snapshots:
       has-symbols: 1.1.0
       safe-regex-test: 1.1.0
 
-  is-text-path@2.0.0:
-    dependencies:
-      text-extensions: 2.4.0
-
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.21
@@ -7440,8 +7308,6 @@ snapshots:
       semver: 7.8.1
 
   jsonify@0.0.1: {}
-
-  jsonparse@1.3.1: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -7560,27 +7426,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  locate-path@7.2.0:
-    dependencies:
-      p-locate: 6.0.0
-
-  lodash.camelcase@4.3.0: {}
-
-  lodash.isplainobject@4.0.6: {}
-
-  lodash.kebabcase@4.1.1: {}
-
   lodash.merge@4.6.2: {}
-
-  lodash.mergewith@4.6.2: {}
-
-  lodash.snakecase@4.1.1: {}
-
-  lodash.startcase@4.4.0: {}
-
-  lodash.uniq@4.5.0: {}
-
-  lodash.upperfirst@4.3.1: {}
 
   log-update@6.1.0:
     dependencies:
@@ -7622,7 +7468,7 @@ snapshots:
 
   mdurl@2.0.0: {}
 
-  meow@12.1.1: {}
+  meow@13.2.0: {}
 
   merge2@1.4.1: {}
 
@@ -7774,17 +7620,9 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-limit@4.0.0:
-    dependencies:
-      yocto-queue: 1.2.2
-
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  p-locate@6.0.0:
-    dependencies:
-      p-limit: 4.0.0
 
   package-json-validator@0.10.2:
     dependencies:
@@ -7802,8 +7640,6 @@ snapshots:
       lines-and-columns: 1.2.4
 
   path-exists@4.0.0: {}
-
-  path-exists@5.0.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -8057,8 +7893,6 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
-  split2@4.2.0: {}
-
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -8163,11 +7997,7 @@ snapshots:
     dependencies:
       "@pkgr/core": 0.3.6
 
-  text-extensions@2.4.0: {}
-
   text-table@0.2.0: {}
-
-  through@2.3.8: {}
 
   tinybench@2.9.0: {}
 
@@ -8255,8 +8085,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@7.24.6: {}
-
-  unicorn-magic@0.1.0: {}
 
   unrs-resolver@1.12.2:
     dependencies:
@@ -8432,6 +8260,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
@@ -8442,9 +8272,16 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yocto-queue@0.1.0: {}
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
-  yocto-queue@1.2.2: {}
+  yocto-queue@0.1.0: {}
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:

--- a/test/e2e/setup.ts
+++ b/test/e2e/setup.ts
@@ -1,4 +1,4 @@
-import { anvilFork } from "@hemilabs/anvil-fork-setup";
+import { anvilFork } from "@hemilabs/anvil-fork-setup/vitest";
 import { hemi } from "viem/chains";
 
 export default anvilFork({


### PR DESCRIPTION
## Description

Bump several dev dependencies to their latest major versions. These are tooling-only changes (testing, linting, commit checks) with no impact on the published package, so no release is needed.

**Commits:**

- 88b6525 Bump @hemilabs/anvil-fork-setup to v2
- b062121 Bump @commitlint/cli to v21
- a5f2695 Bump lint-staged to v17
- 81a9ded Bump knip to v6